### PR TITLE
fix(composition): serverless deploy failing on typescript build on @takeshi's local environment

### DIFF
--- a/packages/composition/.dockerignore
+++ b/packages/composition/.dockerignore
@@ -12,3 +12,5 @@ tsconfig.build.json
 tsconfig.build.tsbuildinfo
 tsconfig.docker.tsbuildinfo
 tsconfig.json
+dist
+node_modules


### PR DESCRIPTION
## Describe your changes
Composition deployment was failing on @takeshi8989's local environment. Due to Docker copying over node_moduels from local