### PR TITLE
chore(lint): increased lint timeout limit for golangci

### DIFF
--- a/packages/service-authentication/Makefile
+++ b/packages/service-authentication/Makefile
@@ -17,4 +17,4 @@ test:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	golangci-lint run ./... --timeout=5m

--- a/packages/service-authorizer/Makefile
+++ b/packages/service-authorizer/Makefile
@@ -16,4 +16,4 @@ test:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	golangci-lint run ./... --timeout=5m

--- a/packages/service-booking/Makefile
+++ b/packages/service-booking/Makefile
@@ -16,4 +16,4 @@ test:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	golangci-lint run ./... --timeout=5m

--- a/packages/service-listing/Makefile
+++ b/packages/service-listing/Makefile
@@ -14,7 +14,7 @@ test:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	golangci-lint run ./... --timeout=5m
 
 .PHONY: generate-mock
 generate-mock:

--- a/packages/service-payment/Makefile
+++ b/packages/service-payment/Makefile
@@ -14,4 +14,4 @@ test:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	golangci-lint run ./... --timeout=5m

--- a/packages/service-user/Makefile
+++ b/packages/service-user/Makefile
@@ -18,7 +18,7 @@ test:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	golangci-lint run ./... --timeout=5m
 
 .PHONY: generate-mock
 generate-mock:


### PR DESCRIPTION
## Describe your changes
Since golangci-lint takes time sometimes, I increased the timeout limit of it

