### PR TITLE
feat(web): add flow where user gets redirected to login if they are not authenticated

### DIFF
--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -1,10 +1,11 @@
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
 import { AuthContext } from "@/context/auth";
 import { useRouter } from "next/router";
 import { Button } from "@/components/button";
 
 const HomePage = () => {
   const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
   const { signOut } = useContext(AuthContext);
 
   const handleSignOut = async () => {
@@ -15,6 +16,24 @@ const HomePage = () => {
       alert("something failed");
     }
   };
+
+  useEffect(() => {
+    setIsLoading(true);
+    const isSignedIn = !!localStorage.getItem("authorizationToken");
+    if (
+      !isSignedIn &&
+      router.pathname !== "/login" &&
+      router.pathname !== "/signup"
+    ) {
+      router.replace("/login");
+    }
+    setIsLoading(false);
+  }, []);
+
+  if (isLoading) {
+    return <div>is loading...</div>;
+  }
+
   return (
     <div>
       <Button label="sign out" onClick={handleSignOut} />


### PR DESCRIPTION
## Describe your changes
Want to set up logic to prevent users from eventually opening the dashboard without being authenticated. This PR enables redirecting the user to the login page instantly when the user doesn't have the `authenticationToken ` stored in localStorage.