### PR TITLE
test(composition): register a listing before initiating the test suites

### DIFF
--- a/packages/composition/src/client/listing.ts
+++ b/packages/composition/src/client/listing.ts
@@ -8,18 +8,26 @@ export default class ListingRestClient extends BaseRestClient {
     longitude: number,
     imageUrls: string[],
     title: string,
-    fee: unknown
+    feeAmount: number,
+    feeCurrency: string,
+    feeType: string
   ) {
-    const response = await this.client.post(`/listings`, {
-      lenderId,
-      streetAddress,
-      latitude,
-      longitude,
-      imageUrls,
-      title,
-      fee,
-    });
-    return response.data;
+    try {
+      const response = await this.client.post(`/listings`, {
+        lenderId,
+        streetAddress,
+        latitude,
+        longitude,
+        imageUrls,
+        title,
+        feeAmount,
+        feeCurrency,
+        feeType,
+      });
+      return response.data;
+    } catch (err) {
+      console.error(err);
+    }
   }
 
   public async findListingById(listingId: string) {

--- a/packages/composition/src/types/global.d.ts
+++ b/packages/composition/src/types/global.d.ts
@@ -4,6 +4,7 @@ declare global {
 
 interface JestMockData {
   uid?: string;
+  listingId?: string;
   mockFirstName: string;
   mockLastName: string;
   mockEmailAddress: string;

--- a/packages/composition/test/setup.ts
+++ b/packages/composition/test/setup.ts
@@ -4,18 +4,31 @@ require("ts-node").register({
 });
 
 import { faker } from "@faker-js/faker";
-import { UserRestClient } from "../src/client";
+import { ListingRestClient, UserRestClient } from "../src/client";
 
-let mockEmailAddress = faker.internet.email();
-let mockFirstName = faker.name.firstName();
-let mockLastName = faker.name.lastName();
-let mockPassword = faker.internet.password();
+const mockEmailAddress = faker.internet.email();
+const mockFirstName = faker.name.firstName();
+const mockLastName = faker.name.lastName();
+const mockPassword = faker.internet.password();
+const mockStreetAddress = faker.address.streetAddress();
+const mockLatitude = faker.address.latitude();
+const mockLongitude = faker.address.longitude();
+const mockImageUrls = [
+  `${faker.image.imageUrl()}/${faker.random.alphaNumeric(20)}`,
+  `${faker.image.imageUrl()}/${faker.random.alphaNumeric(20)}`,
+];
+const mockTitle = faker.company.name();
+const mockFeeAmount = faker.commerce.price();
+const mockFeeCurrency = faker.finance.currencyCode();
+const mockFeeType = "MONTHLY";
 
 module.exports = async function () {
   const uid = await registerUser();
+  const listingId = await registerListing(uid);
 
   global.data = {
     uid,
+    listingId,
     mockEmailAddress,
     mockFirstName,
     mockLastName,


### PR DESCRIPTION
## Describe your changes
Before starting the composition test suites, we want to have a user and a listing associated with the user to test with. This PR contains code to register a listing for the newly created user.