### PR TITLE
feat(web): enable displaying spaces associated with the lender and their current bookings

### DIFF
--- a/web/src/graphql/queries/aws-lambda/space.graphql.ts
+++ b/web/src/graphql/queries/aws-lambda/space.graphql.ts
@@ -1,0 +1,23 @@
+import { gql } from "@apollo/client";
+
+/**
+ * AWS LAMBDA Query
+ */
+export const FIND_SPACES_BY_LENDER_QUERY = gql`
+  query MyQuery($filter: SpaceFilter) {
+    spaces(filter: $filter) {
+      id
+      imageUrls
+      bookings {
+        approved {
+          createdAt
+          description
+        }
+        pending {
+          createdAt
+          description
+        }
+      }
+    }
+  }
+`;

--- a/web/src/graphql/queries/aws-lambda/user.graphql.ts
+++ b/web/src/graphql/queries/aws-lambda/user.graphql.ts
@@ -8,7 +8,7 @@ export const PROFILE_QUERY = gql`
   }
 `;
 
-export const MY_BOOKINGS_QUERY = gql`
+export const FIND_MY_BOOKINGS_QUERY = gql`
   query MyQuery {
     profile {
       bookings {

--- a/web/src/pages/dashboard/guest/index.tsx
+++ b/web/src/pages/dashboard/guest/index.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from "@apollo/client";
 
 import { awsLambdaClient } from "@/clients";
-import { MY_BOOKINGS_QUERY } from "@/graphql/queries";
+import { FIND_MY_BOOKINGS_QUERY } from "@/graphql/queries";
 import { DefaultLayout } from "@/layout";
 import { Booking } from "@/types/interface";
 
 export default function Dashboard() {
-  const { data, loading, error } = useQuery(MY_BOOKINGS_QUERY, {
+  const { data, loading, error } = useQuery(FIND_MY_BOOKINGS_QUERY, {
     client: awsLambdaClient,
   });
   if (loading) {

--- a/web/src/pages/dashboard/lender/index.tsx
+++ b/web/src/pages/dashboard/lender/index.tsx
@@ -1,8 +1,30 @@
+import { awsLambdaClient } from "@/clients";
 import { Button } from "@/components";
+import { AuthContext } from "@/context/auth";
+import { FIND_SPACES_BY_LENDER_QUERY } from "@/graphql/queries/aws-lambda/space.graphql";
 import { DefaultLayout } from "@/layout";
+import { Space } from "@/types/interface";
+import { useQuery } from "@apollo/client";
 import Link from "next/link";
+import { useContext } from "react";
 
 export default function Dashboard() {
+  const { user } = useContext(AuthContext);
+  const { data, loading, error } = useQuery(FIND_SPACES_BY_LENDER_QUERY, {
+    client: awsLambdaClient,
+    variables: {
+      filter: {
+        userId: user ? user.id : "",
+      },
+    },
+  });
+  if (loading) {
+    return <div>loading...</div>;
+  }
+  if (error) {
+    return <div>error...</div>;
+  }
+
   return (
     <DefaultLayout>
       <div>
@@ -11,7 +33,13 @@ export default function Dashboard() {
             <Button onClick={() => {}} label="Add new space" />
           </Link>
         </div>
-        <p className="text-center mt-4">My spaces</p>
+        <div>
+          {data.spaces.length > 0
+            ? data.spaces.map((space: Space) => {
+                return <div key={space.id}>{JSON.stringify(space)}</div>;
+              })
+            : null}
+        </div>
       </div>
     </DefaultLayout>
   );

--- a/web/src/types/interface.ts
+++ b/web/src/types/interface.ts
@@ -23,9 +23,7 @@ export interface SignInParams {
 }
 
 export interface User {
-  email: string;
-  firstName: string;
-  lastName: string;
+  id: string;
   imageUrl?: string;
 }
 


### PR DESCRIPTION
## Describe your changes
When the user redirects to their lender side dashboard, they should be able to see all the spacings they listed with their associated bookings based on the booking status