### PR TITLE
feat(mock): set up a mock server to handle integration tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,14 +16,14 @@ service:slack:
   - packages/service-slack/**
 service:user:
   - packages/service-user/**
+server:mock:
+  - packages/server-mock/**
 scripts:
   - scripts/**
 api:appsync:
   - infrastructure/aws/resources/appsync/**
 terraform:
   - terraform/**
-mobile:
-  - mobile/**
 web:
   - web/**
 github-workflows:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,6 +27,8 @@ terraform:
 web:
   - web/**
 github-workflows:
-  - .github/**
+  - .github/**/**
+dependabot:
+  - .github/dependabot.yml
 vscode:
   - config/settings.json

--- a/packages/server-mock/Dockerfile
+++ b/packages/server-mock/Dockerfile
@@ -1,0 +1,15 @@
+FROM pactfoundation/pact-stub-server:latest
+
+COPY pact /pact
+
+RUN echo '#!/bin/sh' > /entrypoint.sh
+RUN echo 'set -e' >> /entrypoint.sh
+RUN echo 'export PATH=$PATH:/app' >> /entrypoint.sh
+RUN echo 'pact-stub-server' \
+         '-p 8080' \
+         '-d /pact/service-user' \
+         '-d /pact/service-space' \
+         >> /entrypoint.sh 
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/packages/server-mock/Makefile
+++ b/packages/server-mock/Makefile
@@ -1,0 +1,9 @@
+.PHONY: deps-start
+deps-start:
+	@echo "Running Mock Server..."
+	@docker-compose up -d --build
+
+.PHONY: deps-stop
+deps-stop:
+	@echo "Stopping Mock Server..."
+	@docker-compose down --volumes

--- a/packages/server-mock/docker-compose.yml
+++ b/packages/server-mock/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+
+services:
+  mock-server:
+    build: .
+    ports:
+      - "1234:8080"

--- a/packages/server-mock/pact/service-space/example.json
+++ b/packages/server-mock/pact/service-space/example.json
@@ -1,0 +1,31 @@
+{
+  "consumer": {
+    "name": "MyConsumer"
+  },
+  "provider": {
+    "name": "MyProvider"
+  },
+  "interactions": [
+    {
+      "description": "a request for a greeting",
+      "request": {
+        "method": "GET",
+        "path": "/spaces"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "message": "Hello, world from space service!"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0"
+    }
+  }
+}

--- a/packages/server-mock/pact/service-user/example.json
+++ b/packages/server-mock/pact/service-user/example.json
@@ -1,0 +1,31 @@
+{
+  "consumer": {
+    "name": "MyConsumer"
+  },
+  "provider": {
+    "name": "MyProvider"
+  },
+  "interactions": [
+    {
+      "description": "a request for a greeting",
+      "request": {
+        "method": "GET",
+        "path": "/users"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "message": "Hello, world from user service!"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Describe your changes
Currently, we can't set up integration tests that rely on other services on a local environment. Considering we want to implement contract testing in the future, we will use pact-stub-server.